### PR TITLE
feat: add SRE, energy sum and agents to bar chart labels

### DIFF
--- a/sections/helpers/idc_charts.py
+++ b/sections/helpers/idc_charts.py
@@ -90,10 +90,6 @@ def create_barplot(
                 (pl.col("adresse") + " - " + pl.col("egid").cast(pl.Utf8)).alias(
                     "adresse_egid"
                 ),
-                pl.when(pl.col("indice") > 0)
-                .then(pl.col("indice").cast(pl.Int64).cast(pl.Utf8))
-                .otherwise(pl.lit(""))
-                .alias("text"),
                 # Agent 1
                 pl.when(pl.col("agent_energetique_1").is_not_null())
                 .then(
@@ -146,6 +142,34 @@ def create_barplot(
                 .alias("debut"),
                 pl.col("date_fin_periode").cast(pl.Utf8).str.slice(0, 10).alias("fin"),
             ]
+        )
+        # Second pass: build bar label — references agent labels computed above
+        .with_columns(
+            pl.when(pl.col("indice") > 0)
+            .then(
+                pl.col("indice").cast(pl.Int64).cast(pl.Utf8)
+                + " MJ/m²"
+                + "<br>SRE: "
+                + pl.col("sre").cast(pl.Int64).cast(pl.Utf8)
+                + " m²"
+                + "<br>Énergie: "
+                + (pl.col("indice").cast(pl.Float64) * pl.col("sre").cast(pl.Float64))
+                .round(0)
+                .cast(pl.Int64)
+                .cast(pl.Utf8)
+                + " MJ"
+                + pl.when(pl.col("agent_1_label") != "")
+                .then(pl.lit("<br>") + pl.col("agent_1_label"))
+                .otherwise(pl.lit(""))
+                + pl.when(pl.col("agent_2_label") != "")
+                .then(pl.lit("<br>") + pl.col("agent_2_label"))
+                .otherwise(pl.lit(""))
+                + pl.when(pl.col("agent_3_label") != "")
+                .then(pl.lit("<br>") + pl.col("agent_3_label"))
+                .otherwise(pl.lit(""))
+            )
+            .otherwise(pl.lit(""))
+            .alias("text")
         )
     )
 
@@ -205,6 +229,7 @@ def create_barplot(
     fig.update_traces(
         textposition="outside",
         texttemplate="%{text}",
+        textfont=dict(size=10),
         cliponaxis=False,
         hovertemplate=(
             "<b>%{customdata[0]}</b><br>"
@@ -353,7 +378,7 @@ def create_barplot(
             annotation_font_color="red",
         )
 
-    y_max = max(df_full["indice"].max() or 0, seuil or 0) * 1.2
+    y_max = max(df_full["indice"].max() or 0, seuil or 0) * 2.0
 
     fig.update_layout(
         xaxis_title="Année",


### PR DESCRIPTION
Resolves #13 — étiquettes des barres enrichies avec SRE, somme énergie (indice × SRE) et agents énergétiques pour chaque année.

- Split with_columns into two passes so agent labels are available when building the text label
- Bar label now shows: IDC (MJ/m²), SRE (m²), Énergie totale (MJ) and all energy agents with quantities/units
- textfont size reduced to 10 to keep multi-line labels compact
- y_max multiplier raised from 1.2 → 2.0 to prevent label clipping