### PR TITLE
feat: integrate SIT_AUTOR_DOSSIER authorization dossiers via Supabase ETL

### DIFF
--- a/main.py
+++ b/main.py
@@ -408,14 +408,15 @@ try:
 
         # Dossiers d'autorisation de construire
         st.subheader("Dossiers d'autorisation")
-        egids_int = tuple(
-            int(e) for e in egids if e and e not in ("N/A", "", None)
-        )
+        egids_int = tuple(int(e) for e in egids if e and e not in ("N/A", "", None))
         if egids_int:
             autor_records = load_autorizations_by_egids(egids_int)
             if autor_records:
                 df_autor = pl.DataFrame(autor_records).with_columns(
-                    pl.col("date_depot").cast(pl.Utf8).str.slice(0, 10).alias("date_depot"),
+                    pl.col("date_depot")
+                    .cast(pl.Utf8)
+                    .str.slice(0, 10)
+                    .alias("date_depot"),
                     pl.col("egid").cast(pl.Utf8),
                 )
 
@@ -426,15 +427,17 @@ try:
                         df_autor["type_operation"].drop_nulls().unique().to_list()
                     )
                     selected_ops = st.multiselect(
-                        "Type d'opération", options=ops, default=ops,
+                        "Type d'opération",
+                        options=ops,
+                        default=ops,
                         key="autor_filter_operation",
                     )
                 with col_st:
-                    statuts = sorted(
-                        df_autor["statut"].drop_nulls().unique().to_list()
-                    )
+                    statuts = sorted(df_autor["statut"].drop_nulls().unique().to_list())
                     selected_statuts = st.multiselect(
-                        "Statut", options=statuts, default=statuts,
+                        "Statut",
+                        options=statuts,
+                        default=statuts,
                         key="autor_filter_statut",
                     )
 
@@ -443,25 +446,31 @@ try:
                         pl.col("type_operation").is_in(selected_ops)
                     )
                 if selected_statuts:
-                    df_autor = df_autor.filter(
-                        pl.col("statut").is_in(selected_statuts)
-                    )
+                    df_autor = df_autor.filter(pl.col("statut").is_in(selected_statuts))
 
                 st.dataframe(
-                    df_autor.select([
-                        "date_depot", "egid", "id_dossier", "type_dossier",
-                        "type_operation", "statut", "description", "lien_sad",
-                    ]).to_pandas(),
+                    df_autor.select(
+                        [
+                            "date_depot",
+                            "egid",
+                            "id_dossier",
+                            "type_dossier",
+                            "type_operation",
+                            "statut",
+                            "description",
+                            "lien_sad",
+                        ]
+                    ).to_pandas(),
                     use_container_width=True,
                     hide_index=True,
                     column_config={
-                        "date_depot":     st.column_config.TextColumn("Date dépôt"),
-                        "egid":           st.column_config.TextColumn("EGID"),
-                        "id_dossier":     st.column_config.TextColumn("Dossier"),
-                        "type_dossier":   st.column_config.TextColumn("Type"),
+                        "date_depot": st.column_config.TextColumn("Date dépôt"),
+                        "egid": st.column_config.TextColumn("EGID"),
+                        "id_dossier": st.column_config.TextColumn("Dossier"),
+                        "type_dossier": st.column_config.TextColumn("Type"),
                         "type_operation": st.column_config.TextColumn("Opération"),
-                        "statut":         st.column_config.TextColumn("Statut"),
-                        "description":    st.column_config.TextColumn("Description"),
+                        "statut": st.column_config.TextColumn("Statut"),
+                        "description": st.column_config.TextColumn("Description"),
                         "lien_sad": st.column_config.LinkColumn(
                             "Lien SAD", display_text="Consulter"
                         ),

--- a/main.py
+++ b/main.py
@@ -15,6 +15,9 @@ from sections.helpers.db import (
     load_favorites,
     delete_favorite,
     get_all_addresses,
+    init_autorizations_table,
+    refresh_autorizations_db,
+    load_autorizations_by_egids,
 )
 from sections.helpers.idc_api import fetch_idc_data
 from sections.helpers.idc_geo import convert_geometry_for_streamlit, show_map
@@ -45,6 +48,7 @@ CURRENT_YEAR = datetime.now().year
 # Init DB au démarrage, session_state uniquement pour le reload sidebar
 init_history_table()
 init_favorites_table()
+init_autorizations_table()
 
 
 if "address_multiselect" not in st.session_state:
@@ -73,28 +77,41 @@ with st.sidebar:
         step=1,
     )
 
-    st.subheader("Base de données adresses")
+    st.subheader("Base de données")
     if st.button("Mise à jour", width="stretch"):
         status_text = st.empty()
         progress_bar = st.progress(0.0)
         try:
-            n = refresh_adresses_db(
+            # Phase 1 — adresses IDC
+            status_text.caption("Phase 1/2 — Adresses IDC...")
+            n_addr = refresh_adresses_db(
                 URL_INDICE_MOYENNES_3_ANS,
                 progress_bar=progress_bar,
                 status_text=status_text,
             )
-            # Clear the single address cache so the multiselect reloads
             get_all_addresses.clear()
+
+            # Phase 2 — dossiers d'autorisation
+            progress_bar.progress(0.0)
+            status_text.caption("Phase 2/2 — Dossiers d'autorisation...")
+            n_autor = refresh_autorizations_db(
+                progress_bar=progress_bar,
+                status_text=status_text,
+            )
+            load_autorizations_by_egids.clear()
+
             progress_bar.empty()
             status_text.empty()
-            st.success(f"{n:,} adresses chargées et enregistrées.")
+            st.success(
+                f"{n_addr:,} adresses · {n_autor:,} dossiers d'autorisation chargés."
+            )
         except Exception as e:
             progress_bar.empty()
             status_text.empty()
             st.error(f"Erreur lors de la mise à jour : {e}")
     st.caption(
-        "Origine données: [SCANE_INDICE_MOYENNES_3_ANS]"
-        "(https://sitg.ge.ch/donnees/scane-indice-moyennes-3-ans)."
+        "Sources : [IDC SCANE](https://sitg.ge.ch/donnees/scane-indice-moyennes-3-ans)"
+        " · [Autorisations SITG](https://sitg.ge.ch/donnees/sit-autor-dossier)."
     )
 
     st.subheader("Favoris")
@@ -386,6 +403,78 @@ try:
         # Données IDC détaillées
         st.subheader("Données IDC")
         show_dataframe(data_df, seuil=seuil, year_range=year_range)
+
+        #######################################################################
+
+        # Dossiers d'autorisation de construire
+        st.subheader("Dossiers d'autorisation")
+        egids_int = tuple(
+            int(e) for e in egids if e and e not in ("N/A", "", None)
+        )
+        if egids_int:
+            autor_records = load_autorizations_by_egids(egids_int)
+            if autor_records:
+                df_autor = pl.DataFrame(autor_records).with_columns(
+                    pl.col("date_depot").cast(pl.Utf8).str.slice(0, 10).alias("date_depot"),
+                    pl.col("egid").cast(pl.Utf8),
+                )
+
+                # Filter controls
+                col_op, col_st = st.columns(2)
+                with col_op:
+                    ops = sorted(
+                        df_autor["type_operation"].drop_nulls().unique().to_list()
+                    )
+                    selected_ops = st.multiselect(
+                        "Type d'opération", options=ops, default=ops,
+                        key="autor_filter_operation",
+                    )
+                with col_st:
+                    statuts = sorted(
+                        df_autor["statut"].drop_nulls().unique().to_list()
+                    )
+                    selected_statuts = st.multiselect(
+                        "Statut", options=statuts, default=statuts,
+                        key="autor_filter_statut",
+                    )
+
+                if selected_ops:
+                    df_autor = df_autor.filter(
+                        pl.col("type_operation").is_in(selected_ops)
+                    )
+                if selected_statuts:
+                    df_autor = df_autor.filter(
+                        pl.col("statut").is_in(selected_statuts)
+                    )
+
+                st.dataframe(
+                    df_autor.select([
+                        "date_depot", "egid", "id_dossier", "type_dossier",
+                        "type_operation", "statut", "description", "lien_sad",
+                    ]).to_pandas(),
+                    use_container_width=True,
+                    hide_index=True,
+                    column_config={
+                        "date_depot":     st.column_config.TextColumn("Date dépôt"),
+                        "egid":           st.column_config.TextColumn("EGID"),
+                        "id_dossier":     st.column_config.TextColumn("Dossier"),
+                        "type_dossier":   st.column_config.TextColumn("Type"),
+                        "type_operation": st.column_config.TextColumn("Opération"),
+                        "statut":         st.column_config.TextColumn("Statut"),
+                        "description":    st.column_config.TextColumn("Description"),
+                        "lien_sad": st.column_config.LinkColumn(
+                            "Lien SAD", display_text="Consulter"
+                        ),
+                    },
+                )
+                st.caption(
+                    f"{len(df_autor):,} dossier(s) affiché(s) sur {len(autor_records):,} au total."
+                )
+            else:
+                st.info(
+                    "Aucun dossier d'autorisation trouvé pour ces bâtiments. "
+                    "Lancez une mise à jour si la base est vide."
+                )
     else:
         st.warning(
             "Veuillez renseigner une ou plusieurs adresses pour afficher les données IDC."

--- a/sections/helpers/autor_api.py
+++ b/sections/helpers/autor_api.py
@@ -1,0 +1,273 @@
+"""
+Fetch SIT_AUTOR_DOSSIER authorization dossiers and CAD_BATIMENT_HORSOL
+building footprints from SITG ArcGIS REST APIs, then spatial-join them
+to produce records keyed by EGID, ready for Supabase insertion.
+"""
+
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Callable
+
+import geopandas as gpd
+import requests
+from shapely.geometry import MultiPolygon, Point, Polygon
+
+logger = logging.getLogger(__name__)
+
+URL_AUTOR_DOSSIER = (
+    "https://vector.sitg.ge.ch/arcgis/rest/services/"
+    "SIT_AUTOR_DOSSIER/FeatureServer/0/query"
+)
+URL_BATIMENT_HORSOL = (
+    "https://vector.sitg.ge.ch/arcgis/rest/services/"
+    "CAD_BATIMENT_HORSOL/FeatureServer/0/query"
+)
+
+_AUTOR_FIELDS = ",".join([
+    "ID_DOSSIER",
+    "TYPE_DOSSIER",
+    "TYPE_OPERATION",
+    "NOM_DOSSIER",
+    "NO_DOSSIER",
+    "NO_COMPLEMENTAIRE",
+    "STATUT",
+    "DATE_DEPOT",
+    "DESCRIPTION",
+    "OPERATION",
+    "LIEN_SAD",
+    "DATE_MAJ_2",
+])
+
+_BATIMENT_FIELDS = "EGID,COMMUNE"
+
+
+def _ms_to_iso(ms: int | None) -> str | None:
+    if ms is None:
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def _get_count(url: str) -> int:
+    resp = requests.get(
+        url,
+        params={"where": "1=1", "returnCountOnly": "true", "f": "json"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json().get("count", 0)
+
+
+def _fetch_page(
+    url: str,
+    offset: int,
+    chunk_size: int,
+    fields: str,
+    with_geometry: bool,
+) -> list[dict]:
+    for attempt in range(4):
+        try:
+            r = requests.get(
+                url,
+                params={
+                    "where": "1=1",
+                    "outFields": fields,
+                    "returnGeometry": "true" if with_geometry else "false",
+                    "f": "json",
+                    "resultOffset": offset,
+                    "resultRecordCount": chunk_size,
+                },
+                timeout=120,
+            )
+            r.raise_for_status()
+            return r.json().get("features", [])
+        except requests.exceptions.RequestException:
+            if attempt == 3:
+                raise
+            wait = 2 ** (attempt + 1)
+            logger.warning(f"offset={offset} attempt {attempt + 1}/4, retry in {wait}s")
+            time.sleep(wait)
+    return []
+
+
+def _fetch_all_features(
+    url: str,
+    fields: str,
+    with_geometry: bool,
+    chunk_size: int = 1000,
+    max_workers: int = 3,
+    progress_start: float = 0.0,
+    progress_end: float = 1.0,
+    progress_cb: Callable[[float], None] | None = None,
+    status_cb: Callable[[str], None] | None = None,
+) -> list[dict]:
+    """Paginated parallel fetch from an ArcGIS FeatureServer."""
+    total = _get_count(url)
+    if status_cb:
+        status_cb(f"{total:,} enregistrements trouvés — téléchargement...")
+
+    offsets = list(range(0, max(total, 1), chunk_size))
+    completed = 0
+    lock = threading.Lock()
+    all_features: list[dict] = []
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(_fetch_page, url, off, chunk_size, fields, with_geometry): off
+            for off in offsets
+        }
+        for future in as_completed(futures):
+            off = futures[future]
+            try:
+                features = future.result()
+            except Exception as e:
+                raise RuntimeError(f"Échec offset {off}: {e}") from e
+            with lock:
+                all_features.extend(features)
+                completed += 1
+                if progress_cb:
+                    frac = progress_start + (completed / len(offsets)) * (
+                        progress_end - progress_start
+                    )
+                    progress_cb(min(frac, progress_end))
+                if status_cb:
+                    status_cb(f"Téléchargé {len(all_features):,} / ~{total:,}")
+
+    return all_features
+
+
+def _parse_point(geo: dict | None) -> Point | None:
+    if not geo:
+        return None
+    try:
+        return Point(geo["x"], geo["y"])
+    except (KeyError, TypeError):
+        return None
+
+
+def _parse_polygon(geo: dict | None) -> Polygon | MultiPolygon | None:
+    if not geo:
+        return None
+    try:
+        rings = geo.get("rings", [])
+        polys = [Polygon(ring) for ring in rings if len(ring) >= 3]
+        if not polys:
+            return None
+        return MultiPolygon(polys) if len(polys) > 1 else polys[0]
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_and_join_autorizations(
+    url_autor: str = URL_AUTOR_DOSSIER,
+    url_batiment: str = URL_BATIMENT_HORSOL,
+    chunk_size_autor: int = 1000,
+    chunk_size_batiment: int = 500,
+    max_workers: int = 3,
+    progress_cb: Callable[[float], None] | None = None,
+    status_cb: Callable[[str], None] | None = None,
+) -> list[dict]:
+    """
+    Fetch all authorization dossiers and building footprints from SITG,
+    spatial-join them by location to assign EGID per dossier.
+
+    Returns a list of dicts with keys matching the `autorizations` DB table.
+    Authorization points are buffered by 1m before the join to handle
+    edge cases where a point sits exactly on a polygon boundary.
+    """
+    # Stage 1: Authorization dossiers — points (0–40%)
+    if status_cb:
+        status_cb("Chargement des dossiers d'autorisation SITG...")
+    autor_features = _fetch_all_features(
+        url_autor,
+        _AUTOR_FIELDS,
+        with_geometry=True,
+        chunk_size=chunk_size_autor,
+        max_workers=max_workers,
+        progress_start=0.0,
+        progress_end=0.4,
+        progress_cb=progress_cb,
+        status_cb=status_cb,
+    )
+
+    if not autor_features:
+        logger.warning("Aucun dossier d'autorisation retourné par le SITG")
+        return []
+
+    gdf_autor = gpd.GeoDataFrame(
+        [f["attributes"] for f in autor_features],
+        geometry=[_parse_point(f.get("geometry")) for f in autor_features],
+        crs="EPSG:2056",
+    ).dropna(subset=["geometry"])
+
+    # Stage 2: Building polygons (40–80%)
+    if status_cb:
+        status_cb("Chargement des emprises bâtiments SITG...")
+    batiment_features = _fetch_all_features(
+        url_batiment,
+        _BATIMENT_FIELDS,
+        with_geometry=True,
+        chunk_size=chunk_size_batiment,
+        max_workers=max_workers,
+        progress_start=0.4,
+        progress_end=0.8,
+        progress_cb=progress_cb,
+        status_cb=status_cb,
+    )
+
+    if not batiment_features:
+        logger.warning("Aucun bâtiment retourné par le SITG")
+        return []
+
+    gdf_batiment = gpd.GeoDataFrame(
+        [f["attributes"] for f in batiment_features],
+        geometry=[_parse_polygon(f.get("geometry")) for f in batiment_features],
+        crs="EPSG:2056",
+    ).dropna(subset=["geometry", "EGID"])
+
+    # Stage 3: Spatial join (80–90%)
+    if status_cb:
+        status_cb("Jointure spatiale autorisation ↔ bâtiment...")
+
+    gdf_buf = gdf_autor.copy()
+    gdf_buf["geometry"] = gdf_autor.buffer(1)
+
+    gdf_joined = gpd.sjoin(
+        gdf_buf,
+        gdf_batiment[["EGID", "COMMUNE", "geometry"]],
+        how="inner",
+        predicate="intersects",
+    ).drop(columns=["geometry", "index_right"], errors="ignore")
+
+    if progress_cb:
+        progress_cb(0.9)
+
+    # Stage 4: Normalize column names and convert timestamps
+    records = []
+    for row in gdf_joined.to_dict(orient="records"):
+        records.append({
+            "egid": row.get("EGID"),
+            "commune": row.get("COMMUNE"),
+            "id_dossier": row.get("ID_DOSSIER"),
+            "type_dossier": row.get("TYPE_DOSSIER"),
+            "type_operation": row.get("TYPE_OPERATION"),
+            "nom_dossier": row.get("NOM_DOSSIER"),
+            "statut": row.get("STATUT"),
+            "date_depot": _ms_to_iso(row.get("DATE_DEPOT")),
+            "description": row.get("DESCRIPTION"),
+            "operation": row.get("OPERATION"),
+            "lien_sad": row.get("LIEN_SAD"),
+            "date_maj": _ms_to_iso(row.get("DATE_MAJ_2")),
+        })
+
+    if status_cb:
+        status_cb(
+            f"Jointure terminée — {len(records):,} dossiers liés à un bâtiment"
+        )
+
+    return records

--- a/sections/helpers/autor_api.py
+++ b/sections/helpers/autor_api.py
@@ -26,20 +26,22 @@ URL_BATIMENT_HORSOL = (
     "CAD_BATIMENT_HORSOL/FeatureServer/0/query"
 )
 
-_AUTOR_FIELDS = ",".join([
-    "ID_DOSSIER",
-    "TYPE_DOSSIER",
-    "TYPE_OPERATION",
-    "NOM_DOSSIER",
-    "NO_DOSSIER",
-    "NO_COMPLEMENTAIRE",
-    "STATUT",
-    "DATE_DEPOT",
-    "DESCRIPTION",
-    "OPERATION",
-    "LIEN_SAD",
-    "DATE_MAJ_2",
-])
+_AUTOR_FIELDS = ",".join(
+    [
+        "ID_DOSSIER",
+        "TYPE_DOSSIER",
+        "TYPE_OPERATION",
+        "NOM_DOSSIER",
+        "NO_DOSSIER",
+        "NO_COMPLEMENTAIRE",
+        "STATUT",
+        "DATE_DEPOT",
+        "DESCRIPTION",
+        "OPERATION",
+        "LIEN_SAD",
+        "DATE_MAJ_2",
+    ]
+)
 
 _BATIMENT_FIELDS = "EGID,COMMUNE"
 
@@ -118,7 +120,9 @@ def _fetch_all_features(
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
-            executor.submit(_fetch_page, url, off, chunk_size, fields, with_geometry): off
+            executor.submit(
+                _fetch_page, url, off, chunk_size, fields, with_geometry
+            ): off
             for off in offsets
         }
         for future in as_completed(futures):
@@ -250,24 +254,24 @@ def fetch_and_join_autorizations(
     # Stage 4: Normalize column names and convert timestamps
     records = []
     for row in gdf_joined.to_dict(orient="records"):
-        records.append({
-            "egid": row.get("EGID"),
-            "commune": row.get("COMMUNE"),
-            "id_dossier": row.get("ID_DOSSIER"),
-            "type_dossier": row.get("TYPE_DOSSIER"),
-            "type_operation": row.get("TYPE_OPERATION"),
-            "nom_dossier": row.get("NOM_DOSSIER"),
-            "statut": row.get("STATUT"),
-            "date_depot": _ms_to_iso(row.get("DATE_DEPOT")),
-            "description": row.get("DESCRIPTION"),
-            "operation": row.get("OPERATION"),
-            "lien_sad": row.get("LIEN_SAD"),
-            "date_maj": _ms_to_iso(row.get("DATE_MAJ_2")),
-        })
+        records.append(
+            {
+                "egid": row.get("EGID"),
+                "commune": row.get("COMMUNE"),
+                "id_dossier": row.get("ID_DOSSIER"),
+                "type_dossier": row.get("TYPE_DOSSIER"),
+                "type_operation": row.get("TYPE_OPERATION"),
+                "nom_dossier": row.get("NOM_DOSSIER"),
+                "statut": row.get("STATUT"),
+                "date_depot": _ms_to_iso(row.get("DATE_DEPOT")),
+                "description": row.get("DESCRIPTION"),
+                "operation": row.get("OPERATION"),
+                "lien_sad": row.get("LIEN_SAD"),
+                "date_maj": _ms_to_iso(row.get("DATE_MAJ_2")),
+            }
+        )
 
     if status_cb:
-        status_cb(
-            f"Jointure terminée — {len(records):,} dossiers liés à un bâtiment"
-        )
+        status_cb(f"Jointure terminée — {len(records):,} dossiers liés à un bâtiment")
 
     return records

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -13,6 +13,8 @@ from psycopg2.extras import execute_values
 import requests
 import streamlit as st
 
+from sections.helpers.autor_api import fetch_and_join_autorizations
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -84,6 +86,152 @@ def init_favorites_table() -> None:
         """,
         )
     conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Authorization dossiers cache
+# ---------------------------------------------------------------------------
+
+
+def init_autorizations_table() -> None:
+    conn = _get_conn()
+    with conn:
+        _execute(
+            conn,
+            """
+            CREATE TABLE IF NOT EXISTS autorizations (
+                id             SERIAL PRIMARY KEY,
+                egid           BIGINT NOT NULL,
+                commune        TEXT,
+                id_dossier     TEXT,
+                type_dossier   TEXT,
+                type_operation TEXT,
+                nom_dossier    TEXT,
+                statut         TEXT,
+                date_depot     TIMESTAMPTZ,
+                description    TEXT,
+                operation      TEXT,
+                lien_sad       TEXT,
+                date_maj       TIMESTAMPTZ
+            )
+            """,
+        )
+        _execute(
+            conn,
+            "CREATE INDEX IF NOT EXISTS idx_autorizations_egid ON autorizations (egid)",
+        )
+    conn.close()
+
+
+def refresh_autorizations_db(
+    progress_bar=None,
+    status_text=None,
+) -> int:
+    """
+    Full ETL: fetch SIT_AUTOR_DOSSIER + CAD_BATIMENT_HORSOL from SITG,
+    spatial-join to get EGID per dossier, then truncate/insert into Supabase.
+    Returns the number of records inserted.
+    """
+
+    def _status(msg: str) -> None:
+        if status_text is not None:
+            status_text.caption(msg)
+        logger.info(msg)
+
+    def _progress(value: float) -> None:
+        if progress_bar is not None:
+            progress_bar.progress(value)
+
+    records = fetch_and_join_autorizations(
+        progress_cb=lambda f: _progress(f * 0.9),
+        status_cb=_status,
+    )
+
+    if not records:
+        _status("Aucun dossier d'autorisation récupéré.")
+        return 0
+
+    _status(f"Écriture de {len(records):,} dossiers en base...")
+
+    rows = [
+        (
+            r["egid"],
+            r["commune"],
+            r["id_dossier"],
+            r["type_dossier"],
+            r["type_operation"],
+            r["nom_dossier"],
+            r["statut"],
+            r["date_depot"],
+            r["description"],
+            r["operation"],
+            r["lien_sad"],
+            r["date_maj"],
+        )
+        for r in records
+    ]
+
+    conn = _get_conn(statement_timeout_ms=300_000)
+    cur = conn.cursor()
+
+    cur.execute("TRUNCATE TABLE autorizations")
+    conn.commit()
+
+    chunk = 1000
+    total_chunks = (len(rows) + chunk - 1) // chunk
+    for idx, i in enumerate(range(0, len(rows), chunk)):
+        execute_values(
+            cur,
+            """
+            INSERT INTO autorizations
+                (egid, commune, id_dossier, type_dossier, type_operation,
+                 nom_dossier, statut, date_depot, description, operation,
+                 lien_sad, date_maj)
+            VALUES %s
+            """,
+            rows[i : i + chunk],
+        )
+        conn.commit()
+        _progress(0.9 + ((idx + 1) / total_chunks) * 0.1)
+        _status(
+            f"Écriture en base : {min(i + chunk, len(rows)):,} / {len(rows):,} dossiers"
+        )
+
+    cur.close()
+    conn.close()
+    _progress(1.0)
+    _status(f"Terminé — {len(rows):,} dossiers d'autorisation enregistrés.")
+    return len(rows)
+
+
+@st.cache_data(ttl=60)
+def load_autorizations_by_egids(egids: tuple) -> list[dict]:
+    """Load authorization records for a set of EGIDs, most recent first."""
+    if not egids:
+        return []
+    conn = _get_conn()
+    cur = conn.cursor()
+    placeholders = ",".join(["%s"] * len(egids))
+    cur.execute(
+        f"""
+        SELECT egid, commune, id_dossier, type_dossier, type_operation,
+               nom_dossier, statut, date_depot, description, operation,
+               lien_sad, date_maj
+        FROM autorizations
+        WHERE egid IN ({placeholders})
+        ORDER BY date_depot DESC NULLS LAST
+        """,
+        list(egids),
+    )
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    cols = [
+        "egid", "commune", "id_dossier", "type_dossier", "type_operation",
+        "nom_dossier", "statut", "date_depot", "description", "operation",
+        "lien_sad", "date_maj",
+    ]
+    return [dict(zip(cols, r)) for r in rows]
 
 
 # ---------------------------------------------------------------------------

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -227,9 +227,18 @@ def load_autorizations_by_egids(egids: tuple) -> list[dict]:
     cur.close()
     conn.close()
     cols = [
-        "egid", "commune", "id_dossier", "type_dossier", "type_operation",
-        "nom_dossier", "statut", "date_depot", "description", "operation",
-        "lien_sad", "date_maj",
+        "egid",
+        "commune",
+        "id_dossier",
+        "type_dossier",
+        "type_operation",
+        "nom_dossier",
+        "statut",
+        "date_depot",
+        "description",
+        "operation",
+        "lien_sad",
+        "date_maj",
     ]
     return [dict(zip(cols, r)) for r in rows]
 


### PR DESCRIPTION
## Summary

- **New module** `sections/helpers/autor_api.py`: fetches all Geneva building authorization dossiers (`SIT_AUTOR_DOSSIER`) and building footprints (`CAD_BATIMENT_HORSOL`) from the SITG ArcGIS REST APIs using paginated parallel requests, then spatial-joins them with GeoPandas (1m buffer on authorization points) to assign an `EGID` to each dossier.
- **New Supabase table** `autorizations`: stores the joined result (egid, commune, id_dossier, type_dossier, type_operation, statut, date_depot, description, operation, lien_sad, date_maj) with an index on `egid` for fast per-building lookups.
- **Updated refresh flow** in `main.py`: the "Mise a jour" sidebar button now runs in two sequential phases - addresses (phase 1) then authorization dossiers (phase 2) - each with its own progress bar.
- **New "Dossiers d'autorisation" section** in the main view: displayed below the IDC data table for the selected buildings, with `type_operation` and `statut` filter multiselects and a clickable "Consulter" link column pointing to the official SAD consultation page.

## How it works

1. **First run** - click "Mise a jour". The ETL fetches the full Geneva dataset (all authorization dossiers + all building footprints), performs the spatial join in Python, and bulk-inserts into Supabase. This takes several minutes.
2. **Subsequent loads** - `load_autorizations_by_egids()` queries Supabase by EGID tuple and is cached with `@st.cache_data(ttl=60)`, so display is instant.
3. The table auto-creates on app startup via `init_autorizations_table()` (idempotent `CREATE TABLE IF NOT EXISTS`).

## Test plan

- [ ] Run app locally and confirm `autorizations` table is created on startup without errors
- [ ] Click "Mise a jour" and verify both phases complete and success message shows counts for both addresses and dossiers
- [ ] Select a building and confirm the "Dossiers d'autorisation" section appears with correct data
- [ ] Verify filters (type_operation, statut) reduce the displayed rows correctly
- [ ] Verify "Consulter" links open the correct SAD pages
- [ ] Select a building with no authorizations and confirm the info message appears

Generated with [Claude Code](https://claude.com/claude-code)