### PR TITLE
fix: resolve duplicate autorizations widget keys from bad merge

### DIFF
--- a/main.py
+++ b/main.py
@@ -426,9 +426,7 @@ try:
                         key="autor_filter_operation",
                     )
                 with col_st:
-                    statuts = sorted(
-                        df_autor["statut"].drop_nulls().unique().to_list()
-                    )
+                    statuts = sorted(df_autor["statut"].drop_nulls().unique().to_list())
                     selected_statuts = st.multiselect(
                         "Statut",
                         options=statuts,
@@ -441,9 +439,7 @@ try:
                         pl.col("type_operation").is_in(selected_ops)
                     )
                 if selected_statuts:
-                    df_autor = df_autor.filter(
-                        pl.col("statut").is_in(selected_statuts)
-                    )
+                    df_autor = df_autor.filter(pl.col("statut").is_in(selected_statuts))
 
                 st.dataframe(
                     df_autor.select(

--- a/main.py
+++ b/main.py
@@ -322,7 +322,7 @@ with st.expander("Charger depuis une liste d'adresses"):
         placeholder="Ex :\nRue de Rive 10\nRue du Rhône 5",
         key="adresse_import_textarea",
     )
-    if st.button("Charger", key="btn_load_adresses", use_container_width=False):
+    if st.button("Charger", key="btn_load_adresses", width="content"):
         tokens = adresse_raw.splitlines()
         adresses_input = {t.strip() for t in tokens if t.strip()}
 
@@ -414,7 +414,6 @@ try:
                     pl.col("egid").cast(pl.Utf8),
                 )
 
-                # Filter controls
                 col_op, col_st = st.columns(2)
                 with col_op:
                     ops = sorted(
@@ -427,7 +426,9 @@ try:
                         key="autor_filter_operation",
                     )
                 with col_st:
-                    statuts = sorted(df_autor["statut"].drop_nulls().unique().to_list())
+                    statuts = sorted(
+                        df_autor["statut"].drop_nulls().unique().to_list()
+                    )
                     selected_statuts = st.multiselect(
                         "Statut",
                         options=statuts,
@@ -435,67 +436,14 @@ try:
                         key="autor_filter_statut",
                     )
 
-                    col_op, col_st = st.columns(2)
-                    with col_op:
-                        ops = sorted(
-                            df_autor["type_operation"].drop_nulls().unique().to_list()
-                        )
-                        selected_ops = st.multiselect(
-                            "Type d'opération",
-                            options=ops,
-                            default=ops,
-                            key="autor_filter_operation",
-                        )
-                    with col_st:
-                        statuts = sorted(
-                            df_autor["statut"].drop_nulls().unique().to_list()
-                        )
-                        selected_statuts = st.multiselect(
-                            "Statut",
-                            options=statuts,
-                            default=statuts,
-                            key="autor_filter_statut",
-                        )
-
-                    if selected_ops:
-                        df_autor = df_autor.filter(
-                            pl.col("type_operation").is_in(selected_ops)
-                        )
-                    if selected_statuts:
-                        df_autor = df_autor.filter(
-                            pl.col("statut").is_in(selected_statuts)
-                        )
-
-                    st.dataframe(
-                        df_autor.select(
-                            [
-                                "date_depot",
-                                "egid",
-                                "id_dossier",
-                                "type_dossier",
-                                "type_operation",
-                                "statut",
-                                "description",
-                                "lien_sad",
-                            ]
-                        ).to_pandas(),
-                        width="stretch",
-                        hide_index=True,
-                        column_config={
-                            "date_depot": st.column_config.TextColumn("Date dépôt"),
-                            "egid": st.column_config.TextColumn("EGID"),
-                            "id_dossier": st.column_config.TextColumn("Dossier"),
-                            "type_dossier": st.column_config.TextColumn("Type"),
-                            "type_operation": st.column_config.TextColumn("Opération"),
-                            "statut": st.column_config.TextColumn("Statut"),
-                            "description": st.column_config.TextColumn("Description"),
-                            "lien_sad": st.column_config.LinkColumn(
-                                "Lien SAD", display_text="Consulter"
-                            ),
-                        },
+                if selected_ops:
+                    df_autor = df_autor.filter(
+                        pl.col("type_operation").is_in(selected_ops)
                     )
                 if selected_statuts:
-                    df_autor = df_autor.filter(pl.col("statut").is_in(selected_statuts))
+                    df_autor = df_autor.filter(
+                        pl.col("statut").is_in(selected_statuts)
+                    )
 
                 st.dataframe(
                     df_autor.select(
@@ -510,7 +458,7 @@ try:
                             "lien_sad",
                         ]
                     ).to_pandas(),
-                    use_container_width=True,
+                    width="stretch",
                     hide_index=True,
                     column_config={
                         "date_depot": st.column_config.TextColumn("Date dépôt"),


### PR DESCRIPTION
The GitHub merge of PR #17 and #18 left a second col_op/col_st block nested inside `with col_st:`, causing Streamlit to instantiate `autor_filter_operation` and `autor_filter_statut` twice per render and crash with 'multiple elements with same key'. This branch is created directly from the current main HEAD so it merges cleanly. Changes: remove the duplicate block (single columns/multiselect/filter/dataframe pass remains), replace `use_container_width=False` with `width='content'` on the address import button.