### PR TITLE
feat: add authorization count KPIs to Chiffres-cle

### DIFF
--- a/main.py
+++ b/main.py
@@ -388,11 +388,16 @@ try:
 
         st.divider()
 
+        # Load autorization records once here so they can feed both the KPI
+        # row and the detailed table below without a second DB round-trip.
+        egids_int = tuple(int(e) for e in egids if e and e not in ("N/A", "", None))
+        autor_records = load_autorizations_by_egids(egids_int) if egids_int else []
+
         # IDC sections — year_range-dependent, isolated so slider errors don't
         # prevent the autorizations section below from rendering.
         try:
             st.subheader("Chiffres-clé")
-            show_kpis(data_df, seuil=seuil, year_range=year_range)
+            show_kpis(data_df, seuil=seuil, year_range=year_range, autor_records=autor_records)
 
             st.subheader("Plan de situation")
             with st.expander("Afficher la carte", expanded=True):
@@ -413,9 +418,7 @@ try:
         # Dossiers d'autorisation — independent of year_range slider
         st.divider()
         st.subheader("Dossiers d'autorisation")
-        egids_int = tuple(int(e) for e in egids if e and e not in ("N/A", "", None))
         if egids_int:
-            autor_records = load_autorizations_by_egids(egids_int)
             if autor_records:
                 df_autor = pl.DataFrame(autor_records).with_columns(
                     pl.col("date_depot")

--- a/sections/helpers/idc_tables.py
+++ b/sections/helpers/idc_tables.py
@@ -480,7 +480,10 @@ def show_sre_table(
 
 
 def show_kpis(
-    data_df: list[dict], seuil: int = 450, year_range: tuple[int, int] | None = None
+    data_df: list[dict],
+    seuil: int = 450,
+    year_range: tuple[int, int] | None = None,
+    autor_records: list[dict] | None = None,
 ) -> None:
 
     df = pl.from_dicts(data_df).with_columns(
@@ -727,3 +730,23 @@ def show_kpis(
                 "la première et la dernière année de la période sont utilisées."
             ),
         )
+
+    # ── Ligne 2 : Dossiers d'autorisation ─────────────────────────────────────
+    if autor_records is not None:
+        n_autor_total = len(autor_records)
+        n_agr = sum(
+            1 for r in autor_records if r.get("type_operation") == "AGR"
+        )
+        col_a1, col_a2, *_ = st.columns(6)
+        with col_a1:
+            st.metric(
+                label="Dossiers d'autorisation",
+                value=str(n_autor_total) if n_autor_total > 0 else "Aucun",
+                help="Nombre total de dossiers d'autorisation liés aux bâtiments sélectionnés.",
+            )
+        with col_a2:
+            st.metric(
+                label='Opérations "AGR"',
+                value=str(n_agr) if n_agr > 0 else "Aucune",
+                help='Dossiers dont le type d\'opération est "AGR".',
+            )


### PR DESCRIPTION
## Summary

- **New KPI - Dossiers d'autorisation**: total count of authorization dossiers for the selected buildings, shown in the Chiffres-cle section.
- **New KPI - Operations AGR**: count of dossiers whose type_operation equals AGR.
- **No extra DB round-trip**: authorization records are fetched once before the IDC try-block and reused by both show_kpis() and the detailed table. The duplicate egids_int + load_autorizations_by_egids() calls in the dossiers section are removed.

## What changed

- sections/helpers/idc_tables.py: added autor_records param to show_kpis(); renders a second metric row when records are present
- main.py: moved egids_int + autor_records loading before the IDC try-block; passes autor_records to show_kpis(); removed duplicate load

## What a reviewer should know

The AGR filter uses an exact match on type_operation == AGR. If data uses a longer string the count will show 0 and a startswith check should be used instead.

## Test plan

- [ ] Select addresses and verify both new KPIs appear in Chiffres-cle
- [ ] Cross-check total count against the dossiers detail table
- [ ] Select addresses with no authorizations and verify graceful fallback
- [ ] Confirm dossiers table still loads and filters correctly

Generated with Claude Code