### PR TITLE
refactor: replace Supabase/psycopg2 with local SQLite (fixes #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ secrets
 Jupyter
 .claude
 notebook
+idc_local.db

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from sections.helpers.db import (
     delete_favorite,
     delete_history_entry,
     get_all_addresses,
+    init_adresses_table,
     init_autorizations_table,
     init_favorites_table,
     init_history_table,
@@ -49,6 +50,7 @@ CURRENT_YEAR = datetime.now().year
 # Init DB au démarrage, session_state uniquement pour le reload sidebar
 init_history_table()
 init_favorites_table()
+init_adresses_table()
 init_autorizations_table()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "openpyxl>=3.1.5",
     "plotly>=6.0.1",
     "polars>=1.23.0",
-    "psycopg2-binary>=2.9.11",
     "pyproj>=3.7.1",
     "pytest>=8.3.5",
     "ruff>=0.11.0",

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -2,15 +2,14 @@
 
 import json
 import logging
+import sqlite3
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from pathlib import Path
 
 import polars as pl
-import psycopg2
-import psycopg2.pool
-from psycopg2.extras import execute_values
 import requests
 import streamlit as st
 
@@ -19,44 +18,14 @@ from sections.helpers.autor_api import fetch_and_join_autorizations
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-
-@st.cache_resource
-def _get_pool():
-    """Create a thread-safe connection pool shared across all reruns."""
-    s = st.secrets["supabase"]
-    return psycopg2.pool.ThreadedConnectionPool(
-        minconn=1,
-        maxconn=5,
-        host=s["host"],
-        port=s["port"],
-        dbname=s["dbname"],
-        user=s["user"],
-        password=s["password"],
-        sslmode="require",
-        options="-c statement_timeout=30000",
-    )
+DB_PATH = Path(__file__).parent.parent.parent / "idc_local.db"
+_write_lock = threading.Lock()
 
 
-def _get_conn(statement_timeout_ms: int = 30_000):
-    """Get a connection from the pool. Use _put_conn() to return it."""
-    conn = _get_pool().getconn()
-    if statement_timeout_ms != 30_000:
-        with conn.cursor() as cur:
-            cur.execute(f"SET statement_timeout = {statement_timeout_ms}")
+def _get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
     return conn
-
-
-def _put_conn(conn, discard: bool = False) -> None:
-    """Return a connection to the pool. Pass discard=True when a non-default
-    statement_timeout was set, so the next caller gets a clean connection."""
-    _get_pool().putconn(conn, close=discard)
-
-
-def _execute(conn, sql: str, params=None) -> None:
-    """Execute a single statement via cursor. Always pass a connection, not a cursor."""
-    cur = conn.cursor()
-    cur.execute(sql, params)
-    cur.close()
 
 
 # ---------------------------------------------------------------------------
@@ -66,76 +35,88 @@ def _execute(conn, sql: str, params=None) -> None:
 
 def init_history_table() -> None:
     conn = _get_conn()
-    with conn:
-        _execute(
-            conn,
-            """
+    try:
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS consultation_history (
-                id     SERIAL PRIMARY KEY,
+                id     INTEGER PRIMARY KEY AUTOINCREMENT,
                 ts     TEXT NOT NULL,
                 labels TEXT NOT NULL
             )
-        """,
-        )
-        _execute(
-            conn,
-            """
+        """)
+        conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_history_ts
             ON consultation_history (ts DESC)
-        """,
-        )
-    _put_conn(conn)
+        """)
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def init_favorites_table() -> None:
     conn = _get_conn()
-    with conn:
-        _execute(
-            conn,
-            """
+    try:
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS adresses_favorites (
-                id     SERIAL PRIMARY KEY,
+                id     INTEGER PRIMARY KEY AUTOINCREMENT,
                 name   TEXT NOT NULL,
                 labels TEXT NOT NULL UNIQUE
             )
-        """,
-        )
-    _put_conn(conn)
+        """)
+        conn.commit()
+    finally:
+        conn.close()
 
 
-# ---------------------------------------------------------------------------
-# Authorization dossiers cache
-# ---------------------------------------------------------------------------
+def init_adresses_table() -> None:
+    conn = _get_conn()
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS adresses_egid (
+                egid    INTEGER,
+                adresse TEXT,
+                PRIMARY KEY (egid, adresse)
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_adresses_adresse
+            ON adresses_egid (adresse)
+        """)
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def init_autorizations_table() -> None:
     conn = _get_conn()
-    with conn:
-        _execute(
-            conn,
-            """
+    try:
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS autorizations (
-                id             SERIAL PRIMARY KEY,
-                egid           BIGINT NOT NULL,
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                egid           INTEGER NOT NULL,
                 commune        TEXT,
                 id_dossier     TEXT,
                 type_dossier   TEXT,
                 type_operation TEXT,
                 nom_dossier    TEXT,
                 statut         TEXT,
-                date_depot     TIMESTAMPTZ,
+                date_depot     TEXT,
                 description    TEXT,
                 operation      TEXT,
                 lien_sad       TEXT,
-                date_maj       TIMESTAMPTZ
+                date_maj       TEXT
             )
-            """,
-        )
-        _execute(
-            conn,
-            "CREATE INDEX IF NOT EXISTS idx_autorizations_egid ON autorizations (egid)",
-        )
-    _put_conn(conn)
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_autorizations_egid ON autorizations (egid)
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Authorization dossiers cache
+# ---------------------------------------------------------------------------
 
 
 def refresh_autorizations_db(
@@ -144,7 +125,7 @@ def refresh_autorizations_db(
 ) -> int:
     """
     Full ETL: fetch SIT_AUTOR_DOSSIER + CAD_BATIMENT_HORSOL from SITG,
-    spatial-join to get EGID per dossier, then truncate/insert into Supabase.
+    spatial-join to get EGID per dossier, then truncate/insert into local SQLite.
     Returns the number of records inserted.
     """
 
@@ -186,36 +167,33 @@ def refresh_autorizations_db(
         for r in records
     ]
 
-    # Use a long timeout for the bulk write; discard connection afterwards so
-    # the pool doesn't inherit the extended statement_timeout.
-    conn = _get_conn(statement_timeout_ms=300_000)
-    cur = conn.cursor()
+    conn = _get_conn()
+    try:
+        with _write_lock:
+            conn.execute("DELETE FROM autorizations")
+            conn.commit()
 
-    cur.execute("TRUNCATE TABLE autorizations")
-    conn.commit()
+            chunk = 1000
+            total_chunks = (len(rows) + chunk - 1) // chunk
+            for idx, i in enumerate(range(0, len(rows), chunk)):
+                conn.executemany(
+                    """
+                    INSERT INTO autorizations
+                        (egid, commune, id_dossier, type_dossier, type_operation,
+                         nom_dossier, statut, date_depot, description, operation,
+                         lien_sad, date_maj)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                    rows[i : i + chunk],
+                )
+                conn.commit()
+                _progress(0.9 + ((idx + 1) / total_chunks) * 0.1)
+                _status(
+                    f"Écriture en base : {min(i + chunk, len(rows)):,} / {len(rows):,} dossiers"
+                )
+    finally:
+        conn.close()
 
-    chunk = 1000
-    total_chunks = (len(rows) + chunk - 1) // chunk
-    for idx, i in enumerate(range(0, len(rows), chunk)):
-        execute_values(
-            cur,
-            """
-            INSERT INTO autorizations
-                (egid, commune, id_dossier, type_dossier, type_operation,
-                 nom_dossier, statut, date_depot, description, operation,
-                 lien_sad, date_maj)
-            VALUES %s
-            """,
-            rows[i : i + chunk],
-        )
-        conn.commit()
-        _progress(0.9 + ((idx + 1) / total_chunks) * 0.1)
-        _status(
-            f"Écriture en base : {min(i + chunk, len(rows)):,} / {len(rows):,} dossiers"
-        )
-
-    cur.close()
-    _put_conn(conn, discard=True)
     _progress(1.0)
     _status(f"Terminé — {len(rows):,} dossiers d'autorisation enregistrés.")
     return len(rows)
@@ -227,22 +205,22 @@ def load_autorizations_by_egids(egids: tuple) -> list[dict]:
     if not egids:
         return []
     conn = _get_conn()
-    cur = conn.cursor()
-    placeholders = ",".join(["%s"] * len(egids))
-    cur.execute(
-        f"""
-        SELECT egid, commune, id_dossier, type_dossier, type_operation,
-               nom_dossier, statut, date_depot, description, operation,
-               lien_sad, date_maj
-        FROM autorizations
-        WHERE egid IN ({placeholders})
-        ORDER BY date_depot DESC NULLS LAST
-        """,
-        list(egids),
-    )
-    rows = cur.fetchall()
-    cur.close()
-    _put_conn(conn)
+    try:
+        placeholders = ",".join(["?"] * len(egids))
+        cur = conn.execute(
+            f"""
+            SELECT egid, commune, id_dossier, type_dossier, type_operation,
+                   nom_dossier, statut, date_depot, description, operation,
+                   lien_sad, date_maj
+            FROM autorizations
+            WHERE egid IN ({placeholders})
+            ORDER BY date_depot DESC
+            """,
+            list(egids),
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
     cols = [
         "egid",
         "commune",
@@ -273,7 +251,7 @@ def refresh_adresses_db(
     status_text=None,
 ) -> int:
     """
-    Fetch all address/EGID pairs from SITG and rebuild the Supabase table.
+    Fetch all address/EGID pairs from SITG and rebuild the local SQLite table.
     Strategy: parallel fetch with retry, then bulk insert in chunks of 1000.
     """
 
@@ -286,7 +264,6 @@ def refresh_adresses_db(
         if progress_bar is not None:
             progress_bar.progress(value)
 
-    # Step 1: total count
     _status("Connexion au SITG — récupération du nombre total d'adresses...")
     _progress(0.0)
 
@@ -358,7 +335,6 @@ def refresh_adresses_db(
                 _progress(frac * 0.9)
                 _status(f"Téléchargé {len(all_records):,} / ~{total_count:,} adresses")
 
-    # Step 2: deduplicate with Polars
     _status("Dédoublonnage et écriture en base...")
     df = (
         pl.DataFrame(
@@ -372,32 +348,27 @@ def refresh_adresses_db(
     )
     unique_records = df.rows()
 
-    # Step 3: TRUNCATE puis INSERT chunk par chunk, chacun dans sa propre transaction
-    # Use a long timeout for the bulk write; discard connection afterwards.
-    conn = _get_conn(statement_timeout_ms=300_000)
-    cur = conn.cursor()
+    conn = _get_conn()
+    try:
+        with _write_lock:
+            conn.execute("DELETE FROM adresses_egid")
+            conn.commit()
 
-    # TRUNCATE dans sa propre transaction
-    cur.execute("TRUNCATE TABLE adresses_egid")
-    conn.commit()
-
-    chunk = 1000
-    total_chunks = (len(unique_records) + chunk - 1) // chunk
-    for idx, i in enumerate(range(0, len(unique_records), chunk)):
-        execute_values(
-            cur,
-            "INSERT INTO adresses_egid (egid, adresse) VALUES %s ON CONFLICT DO NOTHING",
-            unique_records[i : i + chunk],
-        )
-        conn.commit()  # chaque chunk est une transaction indépendante
-        write_frac = (idx + 1) / total_chunks
-        _progress(0.9 + write_frac * 0.1)
-        _status(
-            f"Écriture en base : {min(i + chunk, len(unique_records)):,} / {len(unique_records):,} adresses"
-        )
-
-    cur.close()
-    _put_conn(conn, discard=True)
+            chunk = 1000
+            total_chunks = (len(unique_records) + chunk - 1) // chunk
+            for idx, i in enumerate(range(0, len(unique_records), chunk)):
+                conn.executemany(
+                    "INSERT OR IGNORE INTO adresses_egid (egid, adresse) VALUES (?,?)",
+                    unique_records[i : i + chunk],
+                )
+                conn.commit()
+                write_frac = (idx + 1) / total_chunks
+                _progress(0.9 + write_frac * 0.1)
+                _status(
+                    f"Écriture en base : {min(i + chunk, len(unique_records)):,} / {len(unique_records):,} adresses"
+                )
+    finally:
+        conn.close()
 
     _progress(1.0)
     _status(f"Terminé — {len(unique_records):,} adresses uniques enregistrées.")
@@ -412,40 +383,46 @@ def refresh_adresses_db(
 def save_history_entry(selected_options: list[str]) -> None:
     labels_json = json.dumps(sorted(selected_options), ensure_ascii=False)
     conn = _get_conn()
-    with conn:
-        cur = conn.cursor()
-        cur.execute(
-            "SELECT id FROM consultation_history WHERE labels = %s", (labels_json,)
-        )
-        if cur.fetchone() is None:
-            cur.execute(
-                "INSERT INTO consultation_history (ts, labels) VALUES (%s, %s)",
-                (datetime.utcnow().isoformat(), labels_json),
+    try:
+        with _write_lock:
+            cur = conn.execute(
+                "SELECT id FROM consultation_history WHERE labels = ?", (labels_json,)
             )
-        cur.close()
-    _put_conn(conn)
+            if cur.fetchone() is None:
+                conn.execute(
+                    "INSERT INTO consultation_history (ts, labels) VALUES (?,?)",
+                    (datetime.utcnow().isoformat(), labels_json),
+                )
+                conn.commit()
+    finally:
+        conn.close()
     load_history.clear()
 
 
 @st.cache_data(ttl=120)
 def load_history(n: int = 20) -> list[dict]:
     conn = _get_conn()
-    cur = conn.cursor()
-    cur.execute(
-        "SELECT id, ts, labels FROM consultation_history ORDER BY ts DESC LIMIT %s",
-        (n,),
-    )
-    rows = cur.fetchall()
-    cur.close()
-    _put_conn(conn)
+    try:
+        cur = conn.execute(
+            "SELECT id, ts, labels FROM consultation_history ORDER BY ts DESC LIMIT ?",
+            (n,),
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
     return [{"id": r[0], "ts": r[1], "labels": json.loads(r[2])} for r in rows]
 
 
 def delete_history_entry(entry_id: int) -> None:
     conn = _get_conn()
-    with conn:
-        _execute(conn, "DELETE FROM consultation_history WHERE id = %s", (entry_id,))
-    _put_conn(conn)
+    try:
+        with _write_lock:
+            conn.execute(
+                "DELETE FROM consultation_history WHERE id = ?", (entry_id,)
+            )
+            conn.commit()
+    finally:
+        conn.close()
     load_history.clear()
 
 
@@ -458,36 +435,41 @@ def save_favorite(name: str, labels: list[str]) -> bool:
     labels_json = json.dumps(sorted(labels), ensure_ascii=False)
     conn = _get_conn()
     try:
-        with conn:
-            _execute(
-                conn,
-                "INSERT INTO adresses_favorites (name, labels) VALUES (%s, %s)",
+        with _write_lock:
+            conn.execute(
+                "INSERT INTO adresses_favorites (name, labels) VALUES (?,?)",
                 (name, labels_json),
             )
+            conn.commit()
         load_favorites.clear()
         return True
-    except psycopg2.errors.UniqueViolation:
+    except sqlite3.IntegrityError:
         return False
     finally:
-        _put_conn(conn)
+        conn.close()
 
 
 @st.cache_data(ttl=120)
 def load_favorites() -> list[dict]:
     conn = _get_conn()
-    cur = conn.cursor()
-    cur.execute("SELECT id, name, labels FROM adresses_favorites ORDER BY name")
-    rows = cur.fetchall()
-    cur.close()
-    _put_conn(conn)
+    try:
+        cur = conn.execute(
+            "SELECT id, name, labels FROM adresses_favorites ORDER BY name"
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
     return [{"id": r[0], "name": r[1], "labels": json.loads(r[2])} for r in rows]
 
 
 def delete_favorite(fav_id: int) -> None:
     conn = _get_conn()
-    with conn:
-        _execute(conn, "DELETE FROM adresses_favorites WHERE id = %s", (fav_id,))
-    _put_conn(conn)
+    try:
+        with _write_lock:
+            conn.execute("DELETE FROM adresses_favorites WHERE id = ?", (fav_id,))
+            conn.commit()
+    finally:
+        conn.close()
     load_favorites.clear()
 
 
@@ -498,17 +480,13 @@ def delete_favorite(fav_id: int) -> None:
 
 @st.cache_resource
 def get_all_addresses() -> pl.DataFrame:
-    """Load address/EGID pairs from Supabase, sorted by address.
-
-    Uses cache_resource (shared object, no copy) instead of cache_data
-    because this DataFrame is read-only and can be safely shared across sessions.
-    """
+    """Load address/EGID pairs from local SQLite, sorted by address."""
     conn = _get_conn()
     try:
-        return pl.read_database(
-            query="SELECT DISTINCT adresse, egid FROM adresses_egid ORDER BY adresse",
-            connection=conn,
+        cur = conn.execute(
+            "SELECT DISTINCT adresse, egid FROM adresses_egid ORDER BY adresse"
         )
+        rows = cur.fetchall()
     except Exception as e:
         logger.error(f"get_all_addresses failed: {e}")
         return pl.DataFrame(
@@ -518,4 +496,14 @@ def get_all_addresses() -> pl.DataFrame:
             }
         )
     finally:
-        _put_conn(conn)
+        conn.close()
+    if not rows:
+        return pl.DataFrame(
+            {
+                "adresse": pl.Series([], dtype=pl.Utf8),
+                "egid": pl.Series([], dtype=pl.Utf8),
+            }
+        )
+    return pl.DataFrame(
+        {"adresse": [r[0] for r in rows], "egid": [r[1] for r in rows]}
+    )


### PR DESCRIPTION
Drop the psycopg2-binary dependency and Supabase connection pool in favour of stdlib sqlite3. All five tables now live in idc_local.db next to the project root, created automatically at startup via a new init_adresses_table() call. Write operations are serialised with a module-level threading.Lock; WAL mode lets reads proceed concurrently.