### PR TITLE
fix: show startup progress bar during DB refresh (fixes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ uv run streamlit run main.py
 ```
 
 ## Source des données
-- [SCANE_INDICE_MOYENNES_3_ANS](https://sitg.ge.ch/donnees/scane-indice-moyennes-3-ans) : données principales pour le calcul de l'IDC
-
+- [SCANE_INDICE_MOYENNES_3_ANS](https://sitg.ge.ch/donnees/scane-indice-moyennes-3-ans) : données IDC
+- [SIT_AUTOR_DOSSIER](https://sitg.ge.ch/donnees/sit-autor-dossier) : autorisations de construire avec un point qui géolocalise le dossier
+- [CAD_BATIMENT_HORSOL](https://sitg.ge.ch/donnees/cad-batiment-horsol) : cadastre des bâtiments hors-sol avec le polygone d'emprise au sol du bâtiment
 
 ## Fonctionnalités
 

--- a/main.py
+++ b/main.py
@@ -51,7 +51,18 @@ init_history_table()
 init_favorites_table()
 init_adresses_table()
 init_autorizations_table()
-refresh_db_at_startup_if_needed(URL_INDICE_MOYENNES_3_ANS)
+
+_startup_placeholder = st.empty()
+with _startup_placeholder.container():
+    st.info("Mise à jour de la base de données en cours…")
+    _pb = st.progress(0)
+    _status = st.empty()
+    _refreshed = refresh_db_at_startup_if_needed(
+        URL_INDICE_MOYENNES_3_ANS,
+        progress_bar=_pb,
+        status_text=_status,
+    )
+_startup_placeholder.empty()
 
 
 if "address_multiselect" not in st.session_state:

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -446,7 +446,9 @@ def refresh_db_at_startup_if_needed(
     autor_bar = _split_progress(progress_bar, 0.5, 0.5)
 
     try:
-        refresh_adresses_db(addresses_url, progress_bar=addr_bar, status_text=status_text)
+        refresh_adresses_db(
+            addresses_url, progress_bar=addr_bar, status_text=status_text
+        )
         get_all_addresses.clear()
         refresh_autorizations_db(progress_bar=autor_bar, status_text=status_text)
         load_autorizations_by_egids.clear()

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -392,6 +392,8 @@ def refresh_adresses_db(
 def refresh_db_at_startup_if_needed(
     addresses_url: str,
     refresh_interval: timedelta = timedelta(days=1),
+    progress_bar=None,
+    status_text=None,
 ) -> bool:
     """
     Refresh local caches at startup if they are empty or stale.
@@ -429,10 +431,24 @@ def refresh_db_at_startup_if_needed(
     if not needs_refresh:
         return False
 
+    def _split_progress(bar, offset: float, span: float):
+        """Return a progress callable that maps [0,1] into [offset, offset+span]."""
+        if bar is None:
+            return None
+
+        class _Bar:
+            def progress(self, v):
+                bar.progress(min(offset + v * span, 1.0))
+
+        return _Bar()
+
+    addr_bar = _split_progress(progress_bar, 0.0, 0.5)
+    autor_bar = _split_progress(progress_bar, 0.5, 0.5)
+
     try:
-        refresh_adresses_db(addresses_url)
+        refresh_adresses_db(addresses_url, progress_bar=addr_bar, status_text=status_text)
         get_all_addresses.clear()
-        refresh_autorizations_db()
+        refresh_autorizations_db(progress_bar=autor_bar, status_text=status_text)
         load_autorizations_by_egids.clear()
     except Exception as exc:
         logger.warning("Automatic startup DB refresh failed: %s", exc)


### PR DESCRIPTION
At startup the app silently ran two expensive SITG fetches (addresses + authorizations) with no UI feedback, which made the server appear frozen and could cause crashes under resource pressure.

- `refresh_db_at_startup_if_needed()` now accepts `progress_bar` and `status_text` params and forwards them to both sub-functions via a `_split_progress` helper that maps each task to its half of the bar (0–50 % addresses, 50–100 % authorizations).
- `main.py` wraps the startup call in a placeholder container that shows an info banner, a live progress bar, and a status caption; the placeholder is cleared once the refresh completes or is skipped.