### PR TITLE
fix: startup progress bar + efficient SITG pagination (fixes #31)

### DIFF
--- a/sections/helpers/autor_api.py
+++ b/sections/helpers/autor_api.py
@@ -5,9 +5,7 @@ to produce records keyed by EGID, ready for Supabase insertion.
 """
 
 import logging
-import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import Callable
 
@@ -68,10 +66,10 @@ def _get_count(url: str) -> int:
 def _fetch_page(
     url: str,
     offset: int,
-    chunk_size: int,
     fields: str,
     with_geometry: bool,
-) -> list[dict]:
+) -> tuple[list[dict], bool]:
+    """Fetch one page; returns (features, exceededTransferLimit)."""
     for attempt in range(4):
         try:
             r = requests.get(
@@ -80,67 +78,53 @@ def _fetch_page(
                     "where": "1=1",
                     "outFields": fields,
                     "returnGeometry": "true" if with_geometry else "false",
+                    "resultType": "standard",
                     "f": "json",
                     "resultOffset": offset,
-                    "resultRecordCount": chunk_size,
                 },
                 timeout=120,
             )
             r.raise_for_status()
-            return r.json().get("features", [])
+            data = r.json()
+            return data.get("features", []), data.get("exceededTransferLimit", False)
         except requests.exceptions.RequestException:
             if attempt == 3:
                 raise
             wait = 2 ** (attempt + 1)
             logger.warning(f"offset={offset} attempt {attempt + 1}/4, retry in {wait}s")
             time.sleep(wait)
-    return []
+    return [], False
 
 
 def _fetch_all_features(
     url: str,
     fields: str,
     with_geometry: bool,
-    chunk_size: int = 1000,
-    max_workers: int = 3,
     progress_start: float = 0.0,
     progress_end: float = 1.0,
     progress_cb: Callable[[float], None] | None = None,
     status_cb: Callable[[str], None] | None = None,
 ) -> list[dict]:
-    """Paginated parallel fetch from an ArcGIS FeatureServer."""
+    """Paginated sequential fetch using resultType=standard + exceededTransferLimit."""
     total = _get_count(url)
     if status_cb:
         status_cb(f"{total:,} enregistrements trouvés — téléchargement...")
 
-    offsets = list(range(0, max(total, 1), chunk_size))
-    completed = 0
-    lock = threading.Lock()
     all_features: list[dict] = []
+    offset = 0
+    exceeded = True
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(
-                _fetch_page, url, off, chunk_size, fields, with_geometry
-            ): off
-            for off in offsets
-        }
-        for future in as_completed(futures):
-            off = futures[future]
-            try:
-                features = future.result()
-            except Exception as e:
-                raise RuntimeError(f"Échec offset {off}: {e}") from e
-            with lock:
-                all_features.extend(features)
-                completed += 1
-                if progress_cb:
-                    frac = progress_start + (completed / len(offsets)) * (
-                        progress_end - progress_start
-                    )
-                    progress_cb(min(frac, progress_end))
-                if status_cb:
-                    status_cb(f"Téléchargé {len(all_features):,} / ~{total:,}")
+    while exceeded:
+        features, exceeded = _fetch_page(url, offset, fields, with_geometry)
+        all_features.extend(features)
+        offset += len(features)
+        if progress_cb:
+            frac = progress_start + min(offset / max(total, 1), 1.0) * (
+                progress_end - progress_start
+            )
+            progress_cb(min(frac, progress_end))
+        if status_cb:
+            status_cb(f"Téléchargé {len(all_features):,} / ~{total:,}")
 
     return all_features
 
@@ -170,9 +154,6 @@ def _parse_polygon(geo: dict | None) -> Polygon | MultiPolygon | None:
 def fetch_and_join_autorizations(
     url_autor: str = URL_AUTOR_DOSSIER,
     url_batiment: str = URL_BATIMENT_HORSOL,
-    chunk_size_autor: int = 1000,
-    chunk_size_batiment: int = 500,
-    max_workers: int = 3,
     progress_cb: Callable[[float], None] | None = None,
     status_cb: Callable[[str], None] | None = None,
 ) -> list[dict]:
@@ -191,8 +172,6 @@ def fetch_and_join_autorizations(
         url_autor,
         _AUTOR_FIELDS,
         with_geometry=True,
-        chunk_size=chunk_size_autor,
-        max_workers=max_workers,
         progress_start=0.0,
         progress_end=0.4,
         progress_cb=progress_cb,
@@ -216,8 +195,6 @@ def fetch_and_join_autorizations(
         url_batiment,
         _BATIMENT_FIELDS,
         with_geometry=True,
-        chunk_size=chunk_size_batiment,
-        max_workers=max_workers,
         progress_start=0.4,
         progress_end=0.8,
         progress_cb=progress_cb,

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -435,7 +435,9 @@ def refresh_db_at_startup_if_needed(
     autor_bar = _split_progress(progress_bar, 0.5, 0.5)
 
     try:
-        refresh_adresses_db(addresses_url, progress_bar=addr_bar, status_text=status_text)
+        refresh_adresses_db(
+            addresses_url, progress_bar=addr_bar, status_text=status_text
+        )
         get_all_addresses.clear()
         refresh_autorizations_db(progress_bar=autor_bar, status_text=status_text)
         load_autorizations_by_egids.clear()

--- a/sections/helpers/db.py
+++ b/sections/helpers/db.py
@@ -5,7 +5,6 @@ import logging
 import sqlite3
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -259,14 +258,13 @@ def load_autorizations_by_egids(egids: tuple) -> list[dict]:
 
 def refresh_adresses_db(
     url: str,
-    chunk_size: int = 2000,
-    max_workers: int = 3,
     progress_bar=None,
     status_text=None,
 ) -> int:
     """
     Fetch all address/EGID pairs from SITG and rebuild the local SQLite table.
-    Strategy: parallel fetch with retry, then bulk insert in chunks of 1000.
+    Strategy: sequential fetch with resultType=standard + exceededTransferLimit pagination,
+    then bulk insert in chunks of 1000.
     """
 
     def _status(msg: str) -> None:
@@ -297,12 +295,11 @@ def refresh_adresses_db(
     total_count = resp.json().get("count", 0)
     _status(f"{total_count:,} adresses trouvées — téléchargement...")
 
-    offsets = list(range(0, total_count, chunk_size))
-    completed_pages = 0
-    lock = threading.Lock()
     all_records: list[tuple] = []
+    offset = 0
+    exceeded = True
 
-    def fetch_page(offset: int) -> list[tuple]:
+    while exceeded:
         for attempt in range(4):
             try:
                 r = requests.get(
@@ -312,42 +309,34 @@ def refresh_adresses_db(
                         "outFields": "adresse,egid",
                         "returnDistinctValues": "true",
                         "returnGeometry": "false",
+                        "resultType": "standard",
                         "f": "json",
                         "resultOffset": offset,
-                        "resultRecordCount": chunk_size,
                     },
                     timeout=60,
                 )
                 r.raise_for_status()
-                features = r.json().get("features", [])
-                return [
+                data = r.json()
+                features = data.get("features", [])
+                exceeded = data.get("exceededTransferLimit", False)
+                records = [
                     (f["attributes"]["egid"], f["attributes"]["adresse"])
                     for f in features
                     if f["attributes"].get("egid") and f["attributes"].get("adresse")
                 ]
+                break
             except requests.exceptions.RequestException:
                 if attempt == 3:
-                    raise
+                    raise RuntimeError(f"Échec offset {offset} après 4 tentatives")
                 wait = 2 ** (attempt + 1)
                 logger.warning(
                     f"offset={offset} attempt {attempt + 1}/4 failed, retry in {wait}s"
                 )
                 time.sleep(wait)
-
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(fetch_page, off): off for off in offsets}
-        for future in as_completed(futures):
-            offset = futures[future]
-            try:
-                records = future.result()
-            except Exception as e:
-                raise RuntimeError(f"Échec offset {offset}: {e}") from e
-            with lock:
-                all_records.extend(records)
-                completed_pages += 1
-                frac = completed_pages / len(offsets)
-                _progress(frac * 0.9)
-                _status(f"Téléchargé {len(all_records):,} / ~{total_count:,} adresses")
+        all_records.extend(records)
+        offset += len(features)
+        _progress(min(offset / max(total_count, 1), 1.0) * 0.9)
+        _status(f"Téléchargé {len(all_records):,} / ~{total_count:,} adresses")
 
     _status("Dédoublonnage et écriture en base...")
     df = (


### PR DESCRIPTION
## Summary

- **Progress bar during startup DB refresh** - the app silently ran two expensive SITG fetches at startup with no UI feedback, making the server appear frozen. A Streamlit placeholder now shows an info banner, a live progress bar (0-50 % addresses, 50-100 % authorizations), and a status caption; it is cleared once the refresh completes or is skipped.
- **Efficient SITG pagination via `resultType=standard` + `exceededTransferLimit`** - replaced fixed-chunk pagination (`resultRecordCount=2000`) so the server returns up to `standardMaxRecordCount` records per call (typically 32 000). Pagination is driven by `exceededTransferLimit` from the response, the correct ArcGIS FeatureServer idiom.
- **Sequential-only fetches** - removed all `ThreadPoolExecutor` parallel fetching that was causing server crashes under resource pressure.

## Files changed

- `main.py` - startup wrapped in a progress placeholder
- `sections/helpers/db.py` - `refresh_db_at_startup_if_needed` forwards `progress_bar`/`status_text`; `refresh_adresses_db` uses `resultType=standard` + `exceededTransferLimit` loop
- `sections/helpers/autor_api.py` - `_fetch_page` returns `(features, exceeded)` tuple; `_fetch_all_features` uses same loop; `chunk_size` params removed

## Test plan

- [x] Fresh DB (delete `idc_local.db`): startup shows progress bar filling 0?100 %, then disappears
- [x] Existing fresh DB: startup completes instantly, no progress bar shown
- [x] Stale DB (>1 day old): refresh runs again with progress bar
- [x] Verify fewer HTTP requests in logs (larger pages from `resultType=standard`)

?? Generated with [Claude Code](https://claude.com/claude-code)